### PR TITLE
Fix set-output GHA deprecation warning (Software-5354)

### DIFF
--- a/.github/workflows/validate-mkdocs.yml
+++ b/.github/workflows/validate-mkdocs.yml
@@ -16,7 +16,7 @@ jobs:
             --strict
 
       - id: format-github-repo
-        run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY#*\/}"
+        run: echo "repo-name=${GITHUB_REPOSITORY#*\/}" >> $GITHUB_OUTPUT
 
       - name: Test links
         timeout-minutes: 10


### PR DESCRIPTION
Fix set-output GHA deprecation warning in validate-mkdocs.yml